### PR TITLE
Clean-up of the name for the shared memory block.

### DIFF
--- a/WISE_Manager_Ui/src/main/java/ca/wise/manager/ui/MainForm.java
+++ b/WISE_Manager_Ui/src/main/java/ca/wise/manager/ui/MainForm.java
@@ -220,8 +220,8 @@ class MainForm extends JFrame implements Translated {
 	 */
 	private void initializeSharedMemory() {
         try {
-            NamedMutex sharedMutex = new NamedMutex("lock.WISE7");
-            SharedMemory sharedMemory = new SharedMemory("memory.WISE7");
+            NamedMutex sharedMutex = new NamedMutex("lock.WISE");
+            SharedMemory sharedMemory = new SharedMemory("memory.WISE");
             systemMemory = new SharedBlock(sharedMutex, sharedMemory);
             systemMemory.updateConfig((byte)Settings.getProcesses(), (short)Settings.getSkipProcesses(), Settings.getNumaLock());
         }


### PR DESCRIPTION
Should we be doing more than this for Manager?  Being, should we be allowing disabling of the shared memory block in WISE Manager, like we do in the C++ EXE?